### PR TITLE
Миронов Арсений. 3822Б1ФИ1. Лабораторная работа 1. Исправление ошибки.

### DIFF
--- a/3822B1FI1/1_gelu_omp/mironov_arseniy/gelu_omp.cpp
+++ b/3822B1FI1/1_gelu_omp/mironov_arseniy/gelu_omp.cpp
@@ -1,7 +1,7 @@
 #include "gelu_omp.h"
 #include <cmath>
 #include <omp.h>
-#define PI 0.636619f
+#define PI 0.797884f
 
 AlignedVector GeluOMP(const AlignedVector& input) {
 	


### PR DESCRIPTION
Совсем забыл взять корень:
константа PI была вычислена как 2.0 / pi, а не std::sqrt(2.0 / pi)